### PR TITLE
Fix: 방의 이미지가 정상 로드되지 않는 버그 수정

### DIFF
--- a/front/pages/ImageRoom/index.tsx
+++ b/front/pages/ImageRoom/index.tsx
@@ -171,6 +171,9 @@ const ImageRoom = () => {
       return;
     }
 
+    setReadStartNum(0);
+    clearRoomImageList();
+
     setFilterStateNum(3);
     setFilterSelectTerm((prev) => ({ ...prev, startDate, endDate }));
     setShowSelectDateForm(false);

--- a/front/pages/ImageRoom/styles.tsx
+++ b/front/pages/ImageRoom/styles.tsx
@@ -166,14 +166,12 @@ export const ContentBox = styled.div`
   top: 120px;
 
   width: 100%;
-  height: calc(100% - 120px);
   padding-bottom: 40px;
 
   .content_box_pos {
     position: relative;
 
     width: 85%;
-    height: 100%;
     margin: auto;
 
     font-size: 1.2rem;


### PR DESCRIPTION
#프론트 폴더

- room에서 이미지 패칭이 정상적으로 작동하도록 intersectionObserver 영역 css 수정
- 기간 선택 시 누락된 이미지를 로드했던 버그 수정 